### PR TITLE
Clarify instructions for running 'tour' locally

### DIFF
--- a/content/welcome.article
+++ b/content/welcome.article
@@ -77,10 +77,14 @@ Click the [[javascript:highlightAndClick(".next-page")]["next"]] button or type 
 #appengine: The stand-alone tour is faster, as it builds and runs the code samples
 #appengine: on your own machine.
 #appengine:
-#appengine: To run the tour locally install and run the tour binary:
+#appengine: To run the tour locally, first install the tour binary:
 #appengine:
 #appengine:   go get golang.org/x/tour
-#appengine:   tour
+#appengine:
+#appengine: This will install `tour` in GOPATH/bin (by default $HOME/go/bin). 
+#appengine: Next, execute the tour binary:
+#appengine:
+#appengine:   $GOPATH/bin/tour
 #appengine:
 #appengine: The tour program will open a web browser displaying
 #appengine: your local version of the tour.


### PR DESCRIPTION
I followed the tour up to this point, but I hadn't read that `go get golang.org/x/tour`
would install `tour` into $GOPATH/bin. I was able to find this info elsewhere but I
think it should be added here, too, so that newcomers can more easily run the tour
locally.